### PR TITLE
feat: integrate data source from data.gov.sg

### DIFF
--- a/estate_agents_dbt/dbt_project.yml
+++ b/estate_agents_dbt/dbt_project.yml
@@ -41,6 +41,12 @@ models:
       +persist_docs:
         relation: true
         columns: true
+    prep:
+      +materialized: table
+      +schema: prep
+      +persist_docs:
+        relation: true
+        columns: true
     facts:
       +materialized: table
       +schema: facts

--- a/estate_agents_dbt/models/dimensions/dim_agents.sql
+++ b/estate_agents_dbt/models/dimensions/dim_agents.sql
@@ -1,8 +1,6 @@
 with
     data_gov_sg_backfill as (
-        select 
-            agent_registration_number,
-            agent_name,
+        select agent_registration_number, agent_name,
         from {{ ref("prep_agents_data_gov_sg") }}
     ),
 

--- a/estate_agents_dbt/models/dimensions/dim_agents.sql
+++ b/estate_agents_dbt/models/dimensions/dim_agents.sql
@@ -1,4 +1,11 @@
 with
+    data_gov_sg_backfill as (
+        select 
+            agent_registration_number,
+            agent_name,
+        from {{ ref("prep_agents_data_gov_sg") }}
+    ),
+
     distinct_agents as (
         select
             agent_id,
@@ -17,6 +24,28 @@ with
         from {{ ref("stg_estate_agents__mobile_numbers") }}
     ),
 
+    unioned as (
+        select
+            agent_id,
+            agent_registration_number,
+            agent_name,
+            agent_aliases,
+            agent_registration_validity_from,
+            agent_registration_validity_to,
+            agent_photo_url,
+        from distinct_agents
+        union all
+        select
+            null as agent_id,
+            agent_registration_number,
+            agent_name,
+            null as agent_aliases,
+            null as agent_registration_validity_from,
+            null as agent_registration_validity_to,
+            null as agent_photo_url,
+        from data_gov_sg_backfill
+    ),
+
     joined as (
         select
             agents.agent_id,
@@ -27,7 +56,7 @@ with
             agents.agent_registration_validity_to,
             agents.agent_photo_url,
             mobile_numbers.agent_mobile_number,
-        from distinct_agents as agents
+        from unioned as agents
         left join mobile_numbers on mobile_numbers.agent_id = agents.agent_id
     )
 

--- a/estate_agents_dbt/models/facts/_facts__models.yml
+++ b/estate_agents_dbt/models/facts/_facts__models.yml
@@ -5,5 +5,7 @@ models:
     columns:
       - name: transaction_id
         data_tests:
-          - not_null
           - unique
+      - name: property_transaction_key
+        data_tests:
+          - not_null

--- a/estate_agents_dbt/models/facts/fact_property_transactions.sql
+++ b/estate_agents_dbt/models/facts/fact_property_transactions.sql
@@ -4,7 +4,7 @@ with
             dbt_utils.union_relations(
                 relations=[
                     ref("prep_property_transactions_scraped_website"),
-                    ref("stg_data_gov_sg__property_transactions_backfill"),
+                    ref("prep_property_transactions_data_gov_sg"),
                 ],
                 source_column_name=None,
             )

--- a/estate_agents_dbt/models/facts/fact_property_transactions.sql
+++ b/estate_agents_dbt/models/facts/fact_property_transactions.sql
@@ -3,20 +3,32 @@ with
         {{
             dbt_utils.union_relations(
                 relations=[
-                    ref("stg_estate_agents__hdb_rental"),
-                    ref("stg_estate_agents__hdb_resale"),
-                    ref("stg_estate_agents__private_rental"),
-                    ref("stg_estate_agents__private_sale"),
+                    ref("prep_property_transactions_scraped_website"),
+                    ref("stg_data_gov_sg__property_transactions_backfill"),
                 ],
                 source_column_name=None,
             )
         }}
     ),
 
+    deduplicated as (
+        select *
+        from union_relations
+        qualify
+            row_number() over (
+                partition by property_transaction_key
+                -- preference for those with transcation_id (from CEA scrapping)
+                order by if(transaction_id is not null, 1, 0) desc
+            )
+            = 1
+    ),
+
     reorder_columns as (
         select
+            property_transaction_key,
             transaction_id,
             transaction_date,
+            transaction_month,
             transaction_type,
             hdb_or_private,
             rental_or_resale,
@@ -26,7 +38,7 @@ with
             property_type,
             client,
             agent_registration_number
-        from union_relations
+        from deduplicated
     )
 
 select *

--- a/estate_agents_dbt/models/marts/_marts__models.yml
+++ b/estate_agents_dbt/models/marts/_marts__models.yml
@@ -62,13 +62,17 @@ models:
 
   - name: mart_property_transactions
     columns:
-      - name: transaction_id
-        description: '{{ doc("transaction_id") }}'
+      - name: property_transaction_key
         data_tests:
           - not_null
           - unique
+      - name: transaction_id
+        description: '{{ doc("transaction_id") }}'
+        data_tests:
+          - unique
       - name: transaction_date
         description: '{{ doc("transaction_date") }}'
+      - name: transaction_month
       - name: transaction_type
         description: '{{ doc("transaction_type") }}'
       - name: hdb_or_private
@@ -96,7 +100,8 @@ models:
       - name: agent_name
         description: '{{ doc("agent_name") }}'
         data_tests:
-          - not_null
+          - not_null:
+              where: transaction_id is not null
       - name: agent_aliases
         description: '{{ doc("agent_aliases") }}'
       - name: agent_registration_validity_from
@@ -110,6 +115,7 @@ models:
       - name: agency_name
         description: '{{ doc("agency_name") }}'
         data_tests:
-          - not_null
+          - not_null:
+              where: transaction_id is not null
       - name: agency_license_number
         description: '{{ doc("agency_license_number") }}'

--- a/estate_agents_dbt/models/marts/mart_property_transactions.sql
+++ b/estate_agents_dbt/models/marts/mart_property_transactions.sql
@@ -1,8 +1,10 @@
 with
     property_transactions as (
         select
+            property_transaction_key,
             transaction_id,
             transaction_date,
+            transaction_month,
             transaction_type,
             hdb_or_private,
             rental_or_resale,
@@ -50,8 +52,10 @@ with
 
     joined as (
         select
+            property_transactions.property_transaction_key,
             property_transactions.transaction_id,
             property_transactions.transaction_date,
+            property_transactions.transaction_month,
             property_transactions.transaction_type,
             property_transactions.hdb_or_private,
             property_transactions.rental_or_resale,
@@ -115,7 +119,7 @@ with
             = backup_matching.agent_registration_number
         qualify
             row_number() over (
-                partition by null_agency_name.transaction_id
+                partition by null_agency_name.property_transaction_key
                 order by
                     case
                         -- match with the nearest value

--- a/estate_agents_dbt/models/prep/prep_agents_data_gov_sg.sql
+++ b/estate_agents_dbt/models/prep/prep_agents_data_gov_sg.sql
@@ -1,0 +1,19 @@
+with
+    source as (
+        select * from {{ ref("stg_data_gov_sg__property_transactions_backfill") }}
+    ),
+
+    distinct_agents as (
+        select distinct agent_registration_number, agent_name
+        from source
+        where agent_registration_number != '-' and agent_name != '-'
+    ),
+
+    find_agents_not_in_scraped as (
+        select *
+        from distinct_agents
+        where agent_registration_number not in (select distinct agent_registration_number from {{ ref("stg_estate_agents__agents") }})
+    )
+
+select *
+from find_agents_not_in_scraped

--- a/estate_agents_dbt/models/prep/prep_agents_data_gov_sg.sql
+++ b/estate_agents_dbt/models/prep/prep_agents_data_gov_sg.sql
@@ -12,7 +12,11 @@ with
     find_agents_not_in_scraped as (
         select *
         from distinct_agents
-        where agent_registration_number not in (select distinct agent_registration_number from {{ ref("stg_estate_agents__agents") }})
+        where
+            agent_registration_number not in (
+                select distinct agent_registration_number
+                from {{ ref("stg_estate_agents__agents") }}
+            )
     )
 
 select *

--- a/estate_agents_dbt/models/prep/prep_property_transactions_data_gov_sg.sql
+++ b/estate_agents_dbt/models/prep/prep_property_transactions_data_gov_sg.sql
@@ -6,6 +6,17 @@ with
     -- complete data from scrapped source starts from oct 2022
     before_oct_2022 as (select * from source where transaction_month < "2022-10-01"),
 
+    scraped_source_summary as (
+        select distinct
+            transaction_month,
+            agent_registration_number,
+            md5(
+                concat(cast(transaction_month as string), agent_registration_number)
+            ) as month_agent_key
+        from {{ ref("prep_property_transactions_scraped_website") }}
+        where transaction_month >= "2022-10-01"
+    ),
+
     on_or_after_oct_2022 as (
         select *
         from source
@@ -13,11 +24,10 @@ with
             transaction_month >= "2022-10-01"
             -- suspect that there are duplicates in the dataset, so will only rely on
             -- the scraped data for periods afterwards
-            and agent_registration_number not in (
-                select distinct agent_registration_number
-                from {{ ref("prep_property_transactions_scraped_website") }}
-                where transaction_month >= "2022-10-01"
+            and md5(
+                concat(cast(transaction_month as string), agent_registration_number)
             )
+            not in (select distinct month_agent_key from scraped_source_summary)
     ),
 
     unioned as (

--- a/estate_agents_dbt/models/prep/prep_property_transactions_data_gov_sg.sql
+++ b/estate_agents_dbt/models/prep/prep_property_transactions_data_gov_sg.sql
@@ -1,0 +1,32 @@
+with
+    source as (
+        select * from {{ ref("stg_data_gov_sg__property_transactions_backfill") }}
+    ),
+
+    -- complete data from scrapped source starts from oct 2022
+    before_oct_2022 as (select * from source where transaction_month < "2022-10-01"),
+
+    on_or_after_oct_2022 as (
+        select *
+        from source
+        where
+            transaction_month >= "2022-10-01"
+            -- suspect that there are duplicates in the dataset, so will only rely on
+            -- the scraped data for periods afterwards
+            and agent_registration_number not in (
+                select distinct agent_registration_number
+                from {{ ref("prep_property_transactions_scraped_website") }}
+                where transaction_month >= "2022-10-01"
+            )
+    ),
+
+    unioned as (
+        select *
+        from before_oct_2022
+        union all
+        select *
+        from on_or_after_oct_2022
+    )
+
+select *
+from unioned

--- a/estate_agents_dbt/models/prep/prep_property_transactions_scraped_website.sql
+++ b/estate_agents_dbt/models/prep/prep_property_transactions_scraped_website.sql
@@ -48,7 +48,7 @@ with
                     cast(
                         row_number() over (
                             partition by
-                                date_trunc(transaction_date, month),
+                                transaction_month,
                                 agent_registration_number,
                                 property_type,
                                 transaction_type,

--- a/estate_agents_dbt/models/prep/prep_property_transactions_scraped_website.sql
+++ b/estate_agents_dbt/models/prep/prep_property_transactions_scraped_website.sql
@@ -36,13 +36,13 @@ with
             md5(
                 concat(
                     coalesce(cast(transaction_month as string), ""),
-                    coalesce(agent_registration_number, ""),
-                    coalesce(property_type, ""),
-                    coalesce(transaction_type, ""),
-                    coalesce(client, ""),
-                    coalesce(property_town, ""),
+                    coalesce(trim(agent_registration_number), ""),
+                    coalesce(trim(property_type), ""),
+                    coalesce(trim(transaction_type), ""),
+                    coalesce(trim(client), ""),
+                    coalesce(trim(property_town), ""),
                     coalesce(cast(property_district_number as string), ""),
-                    coalesce(property_general_location, ""),
+                    coalesce(trim(property_general_location), ""),
                     -- consider that there may be more than one listing with these
                     -- attributes in the same month
                     cast(

--- a/estate_agents_dbt/models/prep/prep_property_transactions_scraped_website.sql
+++ b/estate_agents_dbt/models/prep/prep_property_transactions_scraped_website.sql
@@ -1,0 +1,67 @@
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    ref("stg_estate_agents__hdb_rental"),
+                    ref("stg_estate_agents__hdb_resale"),
+                    ref("stg_estate_agents__private_rental"),
+                    ref("stg_estate_agents__private_sale"),
+                ],
+                source_column_name=None,
+            )
+        }}
+    ),
+
+    reorder_columns as (
+        select
+            transaction_id,
+            transaction_date,
+            date_trunc(transaction_date, month) as transaction_month,
+            transaction_type,
+            hdb_or_private,
+            rental_or_resale,
+            property_town,
+            property_district_number,
+            property_general_location,
+            property_type,
+            client,
+            agent_registration_number
+        from union_relations
+    ),
+
+    add_property_transaction_key as (
+        select
+            *,
+            md5(
+                concat(
+                    coalesce(cast(transaction_month as string), ""),
+                    coalesce(agent_registration_number, ""),
+                    coalesce(property_type, ""),
+                    coalesce(transaction_type, ""),
+                    coalesce(client, ""),
+                    coalesce(property_town, ""),
+                    coalesce(cast(property_district_number as string), ""),
+                    coalesce(property_general_location, ""),
+                    -- consider that there may be more than one listing with these
+                    -- attributes in the same month
+                    cast(
+                        row_number() over (
+                            partition by
+                                date_trunc(transaction_date, month),
+                                agent_registration_number,
+                                property_type,
+                                transaction_type,
+                                client,
+                                property_town,
+                                property_district_number,
+                                property_general_location
+                        ) as string
+                    )
+                )
+            ) as property_transaction_key,
+        from reorder_columns
+    )
+
+select *
+from add_property_transaction_key

--- a/estate_agents_dbt/models/staging/data_gov_sg/_data_gov_sg__sources.yml
+++ b/estate_agents_dbt/models/staging/data_gov_sg/_data_gov_sg__sources.yml
@@ -1,0 +1,5 @@
+version: 2
+sources:
+  - name: data_gov_sg
+    tables:
+      - name: property_transactions_backfill

--- a/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
+++ b/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
@@ -3,7 +3,7 @@
     "EXECUTIVE_CONDOMINIUM": "Executive Condominium",
     "HDB": "HDB",
     "LANDED": "Landed",
-    "STRATA_LANDED": "Strata-Landed"
+    "STRATA_LANDED": "Strata-Landed",
 } %}
 
 {% set transaction_type_map = {
@@ -11,64 +11,97 @@
     "RESALE": "Resale",
     "SUB-SALE": "Sub-sale",
     "ROOM RENTAL": "Room Rental",
-    "WHOLE RENTAL": "Whole Rental"
+    "WHOLE RENTAL": "Whole Rental",
 } %}
 
 {% set represented_map = {
     "BUYER": "Buyer",
     "SELLER": "Seller",
     "TENANT": "Tenant",
-    "LANDLORD": "Landlord"
+    "LANDLORD": "Landlord",
 } %}
 
-with source as (
-    select *
-    from {{ source("data_gov_sg", "property_transactions_backfill") }}
-),
+with
+    source as (
+        select * from {{ source("data_gov_sg", "property_transactions_backfill") }}
+    ),
 
-cleaned as (
-    select
-        trim(salesperson_name) as salesperson_name,
-        parse_date('%b-%Y', transaction_date) as transaction_date,
-        trim(salesperson_reg_num) as salesperson_reg_num,
-        
-        case 
-            {% for key, value in property_type_map.items() %}
-                when property_type = '{{ key }}' then '{{ value }}'
-            {% endfor %}
-        end as property_type,
-        
-        case 
-            {% for key, value in transaction_type_map.items() %}
-                when transaction_type = '{{ key }}' then '{{ value }}'
-            {% endfor %}
-        end as transaction_type,
-        
-        case 
-            {% for key, value in represented_map.items() %}
-                when represented = '{{ key }}' then '{{ value }}'
-            {% endfor %}
-        end as represented,
-        
-        if(town = '-', null, trim(town)) as town,
-        if(district = '-', null, cast(district as int)) as district,
-        if(general_location = '-', null, trim(general_location)) as general_location
-    from source
-),
+    cleaned as (
+        select
+            trim(salesperson_name) as salesperson_name,
+            parse_date('%b-%Y', transaction_date) as transaction_date,
+            trim(salesperson_reg_num) as salesperson_reg_num,
 
-renamed as (
-    select
-        salesperson_name as agent_name,
-        transaction_date as transaction_month,
-        salesperson_reg_num as agent_registration_number,
-        property_type,
-        transaction_type,
-        represented as client,
-        town as property_town,
-        district as property_district_number,
-        general_location as property_general_location
-    from cleaned
-)
+            case
+                {% for key, value in property_type_map.items() %}
+                    when property_type = '{{ key }}' then '{{ value }}'
+                {% endfor %}
+            end as property_type,
+
+            case
+                {% for key, value in transaction_type_map.items() %}
+                    when transaction_type = '{{ key }}' then '{{ value }}'
+                {% endfor %}
+            end as transaction_type,
+
+            case
+                {% for key, value in represented_map.items() %}
+                    when represented = '{{ key }}' then '{{ value }}'
+                {% endfor %}
+            end as represented,
+
+            if(town = '-', null, trim(town)) as town,
+            if(district = '-', null, cast(district as int)) as district,
+            if(general_location = '-', null, trim(general_location)) as general_location
+        from source
+    ),
+
+    renamed as (
+        select
+            salesperson_name as agent_name,
+            transaction_date as transaction_month,
+            salesperson_reg_num as agent_registration_number,
+            property_type,
+            transaction_type,
+            represented as client,
+            town as property_town,
+            district as property_district_number,
+            general_location as property_general_location
+        from cleaned
+    ),
+
+    add_property_transaction_key as (
+        select
+            *,
+            md5(
+                concat(
+                    coalesce(cast(transaction_month as string), ""),
+                    coalesce(agent_registration_number, ""),
+                    coalesce(property_type, ""),
+                    coalesce(transaction_type, ""),
+                    coalesce(client, ""),
+                    coalesce(property_town, ""),
+                    coalesce(cast(property_district_number as string), ""),
+                    coalesce(property_general_location, ""),
+                    -- consider that there may be more than one listing with these
+                    -- attributes in the same month
+                    cast(
+                        row_number() over (
+                            partition by
+                                transaction_month,
+                                agent_registration_number,
+                                property_type,
+                                transaction_type,
+                                client,
+                                property_town,
+                                property_district_number,
+                                property_general_location
+                        ) as string
+                    )
+                )
+            ) as property_transaction_key,
+        from renamed
+    )
 
 select *
-from renamed
+from add_property_transaction_key

--- a/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
+++ b/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
@@ -1,0 +1,53 @@
+with
+    source as (
+        select *
+        from {{ source("data_gov_sg", "property_transactions_backfill") }}
+    ),
+
+    cleaned as (
+        select
+            trim(salesperson_name) as salesperson_name,
+            parse_date('%b-%Y', transaction_date) as transaction_date,
+            trim(salesperson_reg_num) as salesperson_reg_num,
+            case
+                when property_type = "CONDOMINIUM_APARTMENTS" then "Condominium/Apartments"
+                when property_type = "EXECUTIVE_CONDOMINIUM" then "Executive Condominium"
+                when property_type = "HDB" then "HDB"
+                when property_type = "LANDED" then "Landed"
+                when property_type = "STRATA_LANDED" then "Strata-Landed"
+            end as property_type,
+            case
+                when transaction_type="NEW SALE" then "New Sale"
+                when transaction_type="RESALE" then "Resale"
+                when transaction_type="SUB-SALE" then "Sub-sale"
+                when transaction_type="ROOM RENTAL" then "Room Rental"
+                when transaction_type="WHOLE RENTAL" then "Whole Rental"
+            end as transaction_type,
+            case
+                when represented="BUYER" then "Buyer"
+                when represented="SELLER" then "Seller"
+                when represented="TENANT" then "Tenant"
+                when represented="LANDLORD" then "Landlord"
+            end as represented,
+            if(town = "-", null, trim(town)) as town,
+            if(district="-", null, cast(district as int)) as district,
+            if(general_location = "-", null, trim(general_location)) as general_location,
+        from source
+    ),
+
+    renamed as (
+        select
+            salesperson_name as agent_name,
+            transaction_date as transaction_month,
+            salesperson_reg_num as agent_registration_number,
+            property_type,
+            transaction_type,
+            represented as client,
+            town as property_town,
+            district as property_district_number,
+            general_location as property_general_location
+        from cleaned
+    )
+
+select *
+from renamed

--- a/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
+++ b/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
@@ -6,6 +6,22 @@
     "STRATA_LANDED": "Strata-Landed",
 } %}
 
+{% set hdb_or_private_map = {
+    "CONDOMINIUM_APARTMENTS": "private",
+    "EXECUTIVE_CONDOMINIUM": "private",
+    "HDB": "hdb",
+    "LANDED": "private",
+    "STRATA_LANDED": "private",
+} %}
+
+{% set rental_or_resale_map = {
+    "NEW SALE": "sale",
+    "RESALE": "resale",
+    "SUB-SALE": "sale",
+    "ROOM RENTAL": "rental",
+    "WHOLE RENTAL": "rental",
+} %}
+
 {% set transaction_type_map = {
     "NEW SALE": "New Sale",
     "RESALE": "Resale",
@@ -39,10 +55,22 @@ with
             end as property_type,
 
             case
+                {% for key, value in hdb_or_private_map.items() %}
+                    when property_type = '{{ key }}' then '{{ value }}'
+                {% endfor %}
+            end as hdb_or_private,
+
+            case
                 {% for key, value in transaction_type_map.items() %}
                     when transaction_type = '{{ key }}' then '{{ value }}'
                 {% endfor %}
             end as transaction_type,
+
+            case
+                {% for key, value in rental_or_resale_map.items() %}
+                    when transaction_type = '{{ key }}' then '{{ value }}'
+                {% endfor %}
+            end as rental_or_resale,            
 
             case
                 {% for key, value in represented_map.items() %}
@@ -60,13 +88,15 @@ with
         select
             salesperson_name as agent_name,
             transaction_date as transaction_month,
-            salesperson_reg_num as agent_registration_number,
-            property_type,
             transaction_type,
-            represented as client,
+            hdb_or_private,
+            rental_or_resale,
             town as property_town,
             district as property_district_number,
-            general_location as property_general_location
+            general_location as property_general_location,
+            property_type,
+            represented as client,
+            salesperson_reg_num as agent_registration_number,
         from cleaned
     ),
 

--- a/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
+++ b/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
@@ -1,53 +1,74 @@
-with
-    source as (
-        select *
-        from {{ source("data_gov_sg", "property_transactions_backfill") }}
-    ),
+{% set property_type_map = {
+    "CONDOMINIUM_APARTMENTS": "Condominium/Apartments",
+    "EXECUTIVE_CONDOMINIUM": "Executive Condominium",
+    "HDB": "HDB",
+    "LANDED": "Landed",
+    "STRATA_LANDED": "Strata-Landed"
+} %}
 
-    cleaned as (
-        select
-            trim(salesperson_name) as salesperson_name,
-            parse_date('%b-%Y', transaction_date) as transaction_date,
-            trim(salesperson_reg_num) as salesperson_reg_num,
-            case
-                when property_type = "CONDOMINIUM_APARTMENTS" then "Condominium/Apartments"
-                when property_type = "EXECUTIVE_CONDOMINIUM" then "Executive Condominium"
-                when property_type = "HDB" then "HDB"
-                when property_type = "LANDED" then "Landed"
-                when property_type = "STRATA_LANDED" then "Strata-Landed"
-            end as property_type,
-            case
-                when transaction_type="NEW SALE" then "New Sale"
-                when transaction_type="RESALE" then "Resale"
-                when transaction_type="SUB-SALE" then "Sub-sale"
-                when transaction_type="ROOM RENTAL" then "Room Rental"
-                when transaction_type="WHOLE RENTAL" then "Whole Rental"
-            end as transaction_type,
-            case
-                when represented="BUYER" then "Buyer"
-                when represented="SELLER" then "Seller"
-                when represented="TENANT" then "Tenant"
-                when represented="LANDLORD" then "Landlord"
-            end as represented,
-            if(town = "-", null, trim(town)) as town,
-            if(district="-", null, cast(district as int)) as district,
-            if(general_location = "-", null, trim(general_location)) as general_location,
-        from source
-    ),
+{% set transaction_type_map = {
+    "NEW SALE": "New Sale",
+    "RESALE": "Resale",
+    "SUB-SALE": "Sub-sale",
+    "ROOM RENTAL": "Room Rental",
+    "WHOLE RENTAL": "Whole Rental"
+} %}
 
-    renamed as (
-        select
-            salesperson_name as agent_name,
-            transaction_date as transaction_month,
-            salesperson_reg_num as agent_registration_number,
-            property_type,
-            transaction_type,
-            represented as client,
-            town as property_town,
-            district as property_district_number,
-            general_location as property_general_location
-        from cleaned
-    )
+{% set represented_map = {
+    "BUYER": "Buyer",
+    "SELLER": "Seller",
+    "TENANT": "Tenant",
+    "LANDLORD": "Landlord"
+} %}
+
+with source as (
+    select *
+    from {{ source("data_gov_sg", "property_transactions_backfill") }}
+),
+
+cleaned as (
+    select
+        trim(salesperson_name) as salesperson_name,
+        parse_date('%b-%Y', transaction_date) as transaction_date,
+        trim(salesperson_reg_num) as salesperson_reg_num,
+        
+        case 
+            {% for key, value in property_type_map.items() %}
+                when property_type = '{{ key }}' then '{{ value }}'
+            {% endfor %}
+        end as property_type,
+        
+        case 
+            {% for key, value in transaction_type_map.items() %}
+                when transaction_type = '{{ key }}' then '{{ value }}'
+            {% endfor %}
+        end as transaction_type,
+        
+        case 
+            {% for key, value in represented_map.items() %}
+                when represented = '{{ key }}' then '{{ value }}'
+            {% endfor %}
+        end as represented,
+        
+        if(town = '-', null, trim(town)) as town,
+        if(district = '-', null, cast(district as int)) as district,
+        if(general_location = '-', null, trim(general_location)) as general_location
+    from source
+),
+
+renamed as (
+    select
+        salesperson_name as agent_name,
+        transaction_date as transaction_month,
+        salesperson_reg_num as agent_registration_number,
+        property_type,
+        transaction_type,
+        represented as client,
+        town as property_town,
+        district as property_district_number,
+        general_location as property_general_location
+    from cleaned
+)
 
 select *
 from renamed

--- a/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
+++ b/estate_agents_dbt/models/staging/data_gov_sg/stg_data_gov_sg__property_transactions_backfill.sql
@@ -70,7 +70,7 @@ with
                 {% for key, value in rental_or_resale_map.items() %}
                     when transaction_type = '{{ key }}' then '{{ value }}'
                 {% endfor %}
-            end as rental_or_resale,            
+            end as rental_or_resale,
 
             case
                 {% for key, value in represented_map.items() %}
@@ -106,13 +106,13 @@ with
             md5(
                 concat(
                     coalesce(cast(transaction_month as string), ""),
-                    coalesce(agent_registration_number, ""),
-                    coalesce(property_type, ""),
-                    coalesce(transaction_type, ""),
-                    coalesce(client, ""),
-                    coalesce(property_town, ""),
+                    coalesce(trim(agent_registration_number), ""),
+                    coalesce(trim(property_type), ""),
+                    coalesce(trim(transaction_type), ""),
+                    coalesce(trim(client), ""),
+                    coalesce(trim(property_town), ""),
                     coalesce(cast(property_district_number as string), ""),
-                    coalesce(property_general_location, ""),
+                    coalesce(trim(property_general_location), ""),
                     -- consider that there may be more than one listing with these
                     -- attributes in the same month
                     cast(

--- a/estate_agents_dbt/models/staging/stg_estate_agents__hdb_rental.sql
+++ b/estate_agents_dbt/models/staging/stg_estate_agents__hdb_rental.sql
@@ -5,7 +5,7 @@ with
             'hdb' as hdb_or_private,
             'rental' as rental_or_resale,
             id as transaction_id,
-            date(timestamp(transactiondate), "Asia/Singapore"),
+            date(timestamp(transactiondate), "Asia/Singapore") as transaction_date,
             town as property_town,
             'HDB' as property_type,
             client,

--- a/estate_agents_dbt/models/staging/stg_estate_agents__hdb_rental.sql
+++ b/estate_agents_dbt/models/staging/stg_estate_agents__hdb_rental.sql
@@ -5,7 +5,7 @@ with
             'hdb' as hdb_or_private,
             'rental' as rental_or_resale,
             id as transaction_id,
-            date(transactiondate) as transaction_date,
+            date(timestamp(transactiondate), "Asia/Singapore"),
             town as property_town,
             'HDB' as property_type,
             client,

--- a/estate_agents_dbt/models/staging/stg_estate_agents__hdb_resale.sql
+++ b/estate_agents_dbt/models/staging/stg_estate_agents__hdb_resale.sql
@@ -5,7 +5,7 @@ with
             'hdb' as hdb_or_private,
             'resale' as rental_or_resale,
             id as transaction_id,
-            date(transactiondate) as transaction_date,
+            date(timestamp(transactiondate), "Asia/Singapore") as transaction_date,
             town as property_town,
             'HDB' as property_type,
             client,

--- a/estate_agents_dbt/models/staging/stg_estate_agents__mobile_numbers.sql
+++ b/estate_agents_dbt/models/staging/stg_estate_agents__mobile_numbers.sql
@@ -3,12 +3,12 @@ with
     renamed as (
         select
             mobile_number as agent_mobile_number,
-            id as agent_id,
-            registration_number as agent_registration_number,
+            trim(id) as agent_id,
+            trim(registration_number) as agent_registration_number,
             _accessed_at_utc as mobile_number_last_updated_at
         from source
     ),
-    deduplicate as (
+    deduplicated as (
         select *
         from renamed
         qualify
@@ -19,4 +19,4 @@ with
             = 1
     )
 select *
-from renamed
+from deduplicated

--- a/estate_agents_dbt/models/staging/stg_estate_agents__private_rental.sql
+++ b/estate_agents_dbt/models/staging/stg_estate_agents__private_rental.sql
@@ -5,7 +5,7 @@ with
             'private' as hdb_or_private,
             'rental' as rental_or_resale,
             id as transaction_id,
-            date(transactiondate) as transaction_date,
+            date(timestamp(transactiondate), "Asia/Singapore") as transaction_date,
             cast(district as int) as property_district_number,
             generallocation as property_general_location,
             property as property_type,

--- a/estate_agents_dbt/models/staging/stg_estate_agents__private_sale.sql
+++ b/estate_agents_dbt/models/staging/stg_estate_agents__private_sale.sql
@@ -5,7 +5,7 @@ with
             'private' as hdb_or_private,
             'sale' as rental_or_resale,
             id as transaction_id,
-            date(transactiondate) as transaction_date,
+            date(timestamp(transactiondate), "Asia/Singapore") as transaction_date,
             cast(district as int) as property_district_number,
             generallocation as property_general_location,
             property as property_type,


### PR DESCRIPTION
* integration of data from this [data source](https://data.gov.sg/datasets/d_ee7e46d3c57f7865790704632b0aef71/view)
* contains limited data from 2017-2024, there are overlaps with scrapped data (starts sep 2022)

this PR:
* standardises the data source to match scrapped data
* appends data

--

found that there are some agents' data which are not being scraped.
issue was that it was not found in `estate_agents.agents`. will investigate.